### PR TITLE
[FEAT] 참가코드 / 유저이름 UI 및 화면 연결

### DIFF
--- a/Projects/App/Sources/Domain/UseCases/Join/Guest/JoinGuestUseCase.swift
+++ b/Projects/App/Sources/Domain/UseCases/Join/Guest/JoinGuestUseCase.swift
@@ -12,15 +12,16 @@ import RxSwift
 
 protocol JoinGuestUseCaseProtocol {
     var roomCode: BehaviorSubject<String> { get }
-    var nickName: String { get set }
+    var roomName: String { get }
+    var userName: BehaviorSubject<String> { get }
 }
 
 final class JoinGuestUseCase: JoinGuestUseCaseProtocol {
     
     // MARK: - Properties
     var roomCode = BehaviorSubject<String>(value: "")
-    var nickName: String = ""
-    
+    var roomName: String = "방이름"
+    var userName = BehaviorSubject<String>(value: "")
     
     // MARK: - Methods
     init() {}

--- a/Projects/App/Sources/Domain/UseCases/Join/Guest/JoinGuestUseCase.swift
+++ b/Projects/App/Sources/Domain/UseCases/Join/Guest/JoinGuestUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  JoinGuestUseCase.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/09.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+
+protocol JoinGuestUseCaseProtocol {
+    var roomCode: BehaviorSubject<String> { get }
+    var nickName: String { get set }
+}
+
+final class JoinGuestUseCase: JoinGuestUseCaseProtocol {
+    
+    // MARK: - Properties
+    var roomCode = BehaviorSubject<String>(value: "")
+    var nickName: String = ""
+    
+    
+    // MARK: - Methods
+    init() {}
+
+    
+}
+
+// MARK: - Privates
+private extension JoinGuestUseCase {
+    
+}
+

--- a/Projects/App/Sources/Domain/UseCases/Join/Host/JoinHostUseCase.swift
+++ b/Projects/App/Sources/Domain/UseCases/Join/Host/JoinHostUseCase.swift
@@ -25,7 +25,6 @@ final class JoinHostUseCase: JoinHostUseCaseProtocol {
     // MARK: - Methods
     init() {}
 
-    
 }
 
 // MARK: - Privates

--- a/Projects/App/Sources/Domain/UseCases/Join/Host/JoinHostUseCase.swift
+++ b/Projects/App/Sources/Domain/UseCases/Join/Host/JoinHostUseCase.swift
@@ -12,14 +12,14 @@ import RxSwift
 
 protocol JoinHostUseCaseProtocol {
     var roomName: BehaviorSubject<String> { get }
-    var nickName: String { get set }
+    var userName: BehaviorSubject<String> { get }
 }
 
 final class JoinHostUseCase: JoinHostUseCaseProtocol {
     
     // MARK: - Properties
     var roomName = BehaviorSubject<String>(value: "")
-    var nickName: String = ""
+    var userName = BehaviorSubject<String>(value: "")
     
     
     // MARK: - Methods

--- a/Projects/App/Sources/Presentation/Common/Components/View/ProgressView.swift
+++ b/Projects/App/Sources/Presentation/Common/Components/View/ProgressView.swift
@@ -50,4 +50,9 @@ extension ProgressView {
             make.height.equalTo(2)
         }
     }
+    
+    public func setProgress(current: Int, total: Int) {
+        setUI(prog: Float(current) / Float(total))
+    }
+    
 }

--- a/Projects/App/Sources/Presentation/Home/SampleViewController.swift
+++ b/Projects/App/Sources/Presentation/Home/SampleViewController.swift
@@ -34,12 +34,12 @@ class SampleViewController: UIViewController {
     @objc func testButtonDidTap() {
  
         // 방장 플로우
-        let viewModel = RoomNameViewModel(joinAdminUseCase: JoinHostUseCase())
-        self.navigationController?.pushViewController(RoomNameViewController(viewModel: viewModel), animated: true)
+//        let viewModel = RoomNameViewModel(joinAdminUseCase: JoinHostUseCase())
+//        self.navigationController?.pushViewController(RoomNameViewController(viewModel: viewModel), animated: true)
         
         // 참가자 플로우
-//        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
-//        self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
+        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
+        self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
         
     }
 }

--- a/Projects/App/Sources/Presentation/Home/SampleViewController.swift
+++ b/Projects/App/Sources/Presentation/Home/SampleViewController.swift
@@ -32,8 +32,8 @@ class SampleViewController: UIViewController {
     }
     
     @objc func testButtonDidTap() {
-        let viewModel = RoomNameViewModel(joinAdminUseCase: JoinHostUseCase())
-        self.navigationController?.pushViewController(RoomNameViewController(viewModel: viewModel), animated: true)
+        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
+        self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
     }
 }
 

--- a/Projects/App/Sources/Presentation/Home/SampleViewController.swift
+++ b/Projects/App/Sources/Presentation/Home/SampleViewController.swift
@@ -32,8 +32,15 @@ class SampleViewController: UIViewController {
     }
     
     @objc func testButtonDidTap() {
+ 
+        // 방장 플로우
+//        let viewModel = RoomNameViewModel(joinAdminUseCase: JoinHostUseCase())
+//        self.navigationController?.pushViewController(RoomNameViewController(viewModel: viewModel), animated: true)
+        
+        // 참가자 플로우
         let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
         self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
+        
     }
 }
 

--- a/Projects/App/Sources/Presentation/Home/SampleViewController.swift
+++ b/Projects/App/Sources/Presentation/Home/SampleViewController.swift
@@ -34,12 +34,12 @@ class SampleViewController: UIViewController {
     @objc func testButtonDidTap() {
  
         // 방장 플로우
-//        let viewModel = RoomNameViewModel(joinAdminUseCase: JoinHostUseCase())
-//        self.navigationController?.pushViewController(RoomNameViewController(viewModel: viewModel), animated: true)
+        let viewModel = RoomNameViewModel(joinAdminUseCase: JoinHostUseCase())
+        self.navigationController?.pushViewController(RoomNameViewController(viewModel: viewModel), animated: true)
         
         // 참가자 플로우
-        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
-        self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
+//        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
+//        self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
         
     }
 }

--- a/Projects/App/Sources/Presentation/Home/SampleViewModel.swift
+++ b/Projects/App/Sources/Presentation/Home/SampleViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Chanhee Jeong on 2023/02/01.
 //
 
-import RxCocoa
+import RxRelay
 import RxSwift
 
 

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
@@ -1,0 +1,160 @@
+//
+//  UserNameViewController.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/09.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import UIKit
+import RxCocoa
+import RxSwift
+
+final class RoomCodeController: UIViewController {
+    
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+    var viewModel: RoomCodeViewModel?
+    
+    private let progressView = ProgressView(current: 1, total: 4)
+    
+    private let titleView = BasicTitleView(title: "친구에게 받은\n참여 코드를 입력해주세요.")
+    
+    private lazy var textFieldView = BasicTextFieldView(placeholder: "참여 코드 입력")
+    
+    private lazy var nextButton: LargeButton = {
+        $0.setTitle("다음", for: .normal)
+        return $0
+    }(LargeButton(state: false))
+    
+    // MARK: - LifeCycle
+    init(viewModel: RoomCodeViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setNavigationBar()
+        bindViewModel()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+}
+
+// MARK: - Function
+
+extension RoomCodeController {
+    
+    private func setUI() {
+        self.view.backgroundColor = .white
+        textFieldView.textField.becomeFirstResponder()
+        
+        self.view.addSubview(progressView)
+        progressView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        self.view.addSubview(titleView)
+        titleView.snp.makeConstraints {
+            $0.top.equalTo(progressView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        self.view.addSubview(textFieldView)
+        textFieldView.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).inset(-32)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        self.view.addSubview(nextButton)
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    /* Temp */
+    private func setNavigationBar(title: String = "") {
+        let backButton: UIBarButtonItem = UIBarButtonItem(image: UIImage(.chevron_left), style: .plain, target: self, action: #selector(backButtonDidTap))
+        backButton.tintColor = .black
+        let progressLabel = UILabel()
+        progressLabel.text = "1/4"
+        progressLabel.font = UIFont.www.body3
+        let progressItem: UIBarButtonItem = UIBarButtonItem(customView: progressLabel)
+        navigationItem.leftBarButtonItem = backButton
+        navigationItem.rightBarButtonItem = progressItem
+        navigationItem.title = title
+    }
+    
+    @objc func backButtonDidTap() {}
+    
+}
+
+// MARK: - Binding
+private extension RoomCodeController {
+    func bindViewModel() {
+        let input = RoomCodeViewModel.Input(
+            codeTextFieldDidEdit:
+                textFieldView.textField.rx.text.orEmpty.asObservable(),
+            nextButtonDidTap:
+                self.nextButton.rx.tap.asObservable(),
+            backButtonDidTap:
+                self.navigationItem.leftBarButtonItem!.rx.tap.asObservable()
+        )
+        
+        let output = self.viewModel?.transform(input: input, disposeBag: self.disposeBag)
+        
+        self.bindPager(output: output)
+        
+        output?.nextButtonMakeEnable
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] isEnabled in
+                if isEnabled == true {
+                    self?.nextButton.setButtonState(true)
+                } else {
+                    self?.nextButton.setButtonState(false)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+    }
+    
+    func bindPager(output: RoomCodeViewModel.Output?){
+        output?.navigatePage
+            .asDriver(onErrorJustReturn: .error)
+            .drive(onNext: { [weak self] page in
+                switch page {
+                case .back:
+                    self?.navigationController?.popViewController(animated: true)
+                case .nickName:
+                    // TODO: 다음페이지 연결
+                    print("다음페이지로 넘어갑니다")
+                case .error: break
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+
+// MARK: - Preview
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct RoomCodeController_Preview: PreviewProvider {
+    static var previews: some View {
+        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
+        RoomCodeController(viewModel: viewModel).toPreview()
+    }
+}
+#endif

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SnapKit
 import RxCocoa
 import RxSwift
 
@@ -137,6 +138,7 @@ private extension RoomCodeController {
                     self?.navigationController?.popViewController(animated: true)
                 case .nickName:
                     // VM에서 코드 검증 단계
+                    self?.textFieldView.textField.resignFirstResponder()
                     let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
                     self?.navigationController?.pushViewController(UserNameViewController(viewModel: viewModel, userMode: .guest), animated: true)
                 case .error: break

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
@@ -72,7 +72,7 @@ extension RoomCodeController {
         
         self.view.addSubview(textFieldView)
         textFieldView.snp.makeConstraints {
-            $0.top.equalTo(titleView.snp.bottom).inset(-32)
+            $0.top.equalTo(titleView.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
         

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
@@ -136,8 +136,9 @@ private extension RoomCodeController {
                 case .back:
                     self?.navigationController?.popViewController(animated: true)
                 case .nickName:
-                    // TODO: 다음페이지 연결
-                    print("다음페이지로 넘어갑니다")
+                    // VM에서 코드 검증 단계
+                    let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
+                    self?.navigationController?.pushViewController(UserNameViewController(viewModel: viewModel, userMode: .guest), animated: true)
                 case .error: break
                 }
             })

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewController.swift
@@ -139,7 +139,7 @@ private extension RoomCodeController {
                 case .nickName:
                     // VM에서 코드 검증 단계
                     self?.textFieldView.textField.resignFirstResponder()
-                    let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
+                    let viewModel = UserNameViewModel(joinGuestUseCase: self?.viewModel?.getUseCase())
                     self?.navigationController?.pushViewController(UserNameViewController(viewModel: viewModel, userMode: .guest), animated: true)
                 case .error: break
                 }

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
@@ -54,11 +54,7 @@ final class RoomCodeViewModel: BaseViewModel {
         self.usecase.roomCode
             .compactMap { $0 }
             .subscribe(onNext: { roomname in
-                if roomname != "" {
-                    output.nextButtonMakeEnable.accept(true)
-                } else {
-                    output.nextButtonMakeEnable.accept(false)
-                }
+                output.nextButtonMakeEnable.accept(roomname != "" ? true : false)
             })
             .disposed(by: disposeBag)
         

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
@@ -41,6 +41,10 @@ final class RoomCodeViewModel: BaseViewModel {
         return makeOutput(with:  input, disposeBag: disposeBag)
     }
     
+    func getUseCase() -> JoinGuestUseCase {
+        return self.usecase
+    }
+    
     private func handleInput(_ input: Input, disposeBag: DisposeBag) {
         input.codeTextFieldDidEdit
             .bind(to: self.usecase.roomCode)

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 com.promise8. All rights reserved.
 //
 
-import RxCocoa
+import RxRelay
 import RxSwift
 
 enum RoomCodePager {

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
@@ -9,7 +9,7 @@
 import RxCocoa
 import RxSwift
 
-enum UserNamePager {
+enum RoomCodePager {
     case back
     case nickName
     case error
@@ -29,7 +29,7 @@ final class RoomCodeViewModel: BaseViewModel {
     struct Output {
         var roomNameTextFieldText = BehaviorRelay<String>(value: "")
         var nextButtonMakeEnable = BehaviorRelay<Bool>(value: false)
-        var navigatePage = PublishRelay<RoomNamePager>()
+        var navigatePage = PublishRelay<RoomCodePager>()
     }
     
     init(joinGuestUseCase: JoinGuestUseCase) {

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
@@ -1,0 +1,79 @@
+//
+//  UserNameViewModel.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/09.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+
+enum UserNamePager {
+    case back
+    case nickName
+    case error
+}
+
+final class RoomCodeViewModel: BaseViewModel {
+    
+    // MARK: - Properties
+    private let usecase: JoinGuestUseCase
+    
+    struct Input {
+        let codeTextFieldDidEdit: Observable<String>
+        let nextButtonDidTap: Observable<Void>
+        let backButtonDidTap: Observable<Void>
+    }
+    
+    struct Output {
+        var roomNameTextFieldText = BehaviorRelay<String>(value: "")
+        var nextButtonMakeEnable = BehaviorRelay<Bool>(value: false)
+        var navigatePage = PublishRelay<RoomNamePager>()
+    }
+    
+    init(joinGuestUseCase: JoinGuestUseCase) {
+        self.usecase = joinGuestUseCase
+    }
+
+    // MARK: - Transform
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+        self.handleInput(input, disposeBag: disposeBag)
+        return makeOutput(with:  input, disposeBag: disposeBag)
+    }
+    
+    private func handleInput(_ input: Input, disposeBag: DisposeBag) {
+        input.codeTextFieldDidEdit
+            .bind(to: self.usecase.roomCode)
+            .disposed(by: disposeBag)
+    }
+    
+    private func makeOutput(with input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        
+        self.usecase.roomCode
+            .compactMap { $0 }
+            .subscribe(onNext: { roomname in
+                if roomname != "" {
+                    output.nextButtonMakeEnable.accept(true)
+                } else {
+                    output.nextButtonMakeEnable.accept(false)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        input.backButtonDidTap
+            .subscribe(onNext: {
+                output.navigatePage.accept(.back)
+            })
+            .disposed(by: disposeBag)
+        
+        input.nextButtonDidTap
+            .subscribe(onNext: {
+                output.navigatePage.accept(.nickName)
+            })
+            .disposed(by: disposeBag)
+        
+        return output
+    }
+}

--- a/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomCode/RoomCodeViewModel.swift
@@ -27,7 +27,6 @@ final class RoomCodeViewModel: BaseViewModel {
     }
     
     struct Output {
-        var roomNameTextFieldText = BehaviorRelay<String>(value: "")
         var nextButtonMakeEnable = BehaviorRelay<Bool>(value: false)
         var navigatePage = PublishRelay<RoomCodePager>()
     }

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
@@ -72,7 +72,7 @@ extension RoomNameViewController {
         
         self.view.addSubview(textFieldView)
         textFieldView.snp.makeConstraints {
-            $0.top.equalTo(titleView.snp.bottom).inset(-32)
+            $0.top.equalTo(titleView.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
         

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
@@ -134,7 +134,7 @@ private extension RoomNameViewController {
                     self?.navigationController?.popViewController(animated: true)
                 case .nickName:
                     self?.textFieldView.textField.resignFirstResponder()
-                    let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
+                    let viewModel = UserNameViewModel(joinHostUseCase: JoinHostUseCase())
                     self?.navigationController?.pushViewController(UserNameViewController(viewModel: viewModel, userMode: .host), animated: true)
                 case .error: break
                 }

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
@@ -134,7 +134,7 @@ private extension RoomNameViewController {
                     self?.navigationController?.popViewController(animated: true)
                 case .nickName:
                     self?.textFieldView.textField.resignFirstResponder()
-                    let viewModel = UserNameViewModel(joinHostUseCase: JoinHostUseCase())
+                    let viewModel = UserNameViewModel(joinHostUseCase: self?.viewModel?.getUseCase())
                     self?.navigationController?.pushViewController(UserNameViewController(viewModel: viewModel, userMode: .host), animated: true)
                 case .error: break
                 }

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SnapKit
 import RxCocoa
 import RxSwift
 
@@ -132,8 +133,9 @@ private extension RoomNameViewController {
                 case .back:
                     self?.navigationController?.popViewController(animated: true)
                 case .nickName:
-                    // TODO: 다음페이지 연결
-                    print("다음페이지로 넘어갑니다")
+                    self?.textFieldView.textField.resignFirstResponder()
+                    let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
+                    self?.navigationController?.pushViewController(UserNameViewController(viewModel: viewModel, userMode: .host), animated: true)
                 case .error: break
                 }
             })

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewModel.swift
@@ -41,6 +41,10 @@ final class RoomNameViewModel: BaseViewModel {
         return makeOutput(with:  input, disposeBag: disposeBag)
     }
     
+    func getUseCase() -> JoinHostUseCase {
+        return self.usecase
+    }
+    
     private func handleInput(_ input: Input, disposeBag: DisposeBag) {
         input.roomNameTextFieldDidEdit
             .bind(to: self.usecase.roomName)

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewModel.swift
@@ -27,7 +27,6 @@ final class RoomNameViewModel: BaseViewModel {
     }
     
     struct Output {
-        var roomNameTextFieldText = BehaviorRelay<String>(value: "")
         var nextButtonMakeEnable = BehaviorRelay<Bool>(value: false)
         var navigatePage = PublishRelay<RoomNamePager>()
     }

--- a/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/RoomName/RoomNameViewModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 com.promise8. All rights reserved.
 //
 
-import RxCocoa
+import RxRelay
 import RxSwift
 
 enum RoomNamePager {

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SnapKit
 import RxCocoa
 import RxSwift
 
@@ -21,7 +22,7 @@ final class UserNameViewController: UIViewController {
     
     private let titleView = BasicTitleView(title: "약속방에서 사용하실\n닉네임을 알려주세요.")
     
-    private lazy var textFieldView = BasicTextFieldView(placeholder: "참여 코드 입력")
+    private lazy var textFieldView = BasicTextFieldView(placeholder: "닉네임 입력")
     
     private lazy var nextButton: LargeButton = {
         $0.setTitle("다음", for: .normal)
@@ -39,6 +40,10 @@ final class UserNameViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        textFieldView.textField.becomeFirstResponder()
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
@@ -67,7 +72,7 @@ extension UserNameViewController {
         }
         
         self.view.backgroundColor = .white
-        textFieldView.textField.becomeFirstResponder()
+//        textFieldView.textField.becomeFirstResponder()
         
         self.view.addSubview(progressView)
         progressView.snp.makeConstraints {

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
@@ -86,7 +86,7 @@ extension UserNameViewController {
         
         self.view.addSubview(textFieldView)
         textFieldView.snp.makeConstraints {
-            $0.top.equalTo(titleView.snp.bottom).inset(-32)
+            $0.top.equalTo(titleView.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
         

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
@@ -1,0 +1,174 @@
+//
+//  UserNameViewController.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/09.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import UIKit
+import RxCocoa
+import RxSwift
+
+final class UserNameViewController: UIViewController {
+    
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+    var viewModel: UserNameViewModel?
+    var userMode: UserType
+    
+    private let progressView = ProgressView(current: 0, total: 0)
+    
+    private let titleView = BasicTitleView(title: "약속방에서 사용하실\n닉네임을 알려주세요.")
+    
+    private lazy var textFieldView = BasicTextFieldView(placeholder: "참여 코드 입력")
+    
+    private lazy var nextButton: LargeButton = {
+        $0.setTitle("다음", for: .normal)
+        return $0
+    }(LargeButton(state: false))
+    
+    // MARK: - LifeCycle
+    init(viewModel: UserNameViewModel, userMode: UserType) {
+        self.viewModel = viewModel
+        self.userMode = userMode
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        bindViewModel()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+}
+
+// MARK: - Function
+
+extension UserNameViewController {
+    
+    private func setUI() {
+        
+        // TODO: rx적용
+        switch userMode {
+        case .host:
+            progressView.setProgress(current: 2, total: 6)
+            self.setNavigationBar(title: "넥스터즈 뒷풀이", step: "2/6")
+        case .guest:
+            progressView.setProgress(current: 2, total: 4)
+            self.setNavigationBar(title: "넥스터즈 뒷풀이", step: "2/4")
+        }
+        
+        self.view.backgroundColor = .white
+        textFieldView.textField.becomeFirstResponder()
+        
+        self.view.addSubview(progressView)
+        progressView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        self.view.addSubview(titleView)
+        titleView.snp.makeConstraints {
+            $0.top.equalTo(progressView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        self.view.addSubview(textFieldView)
+        textFieldView.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).inset(-32)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        self.view.addSubview(nextButton)
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    /* Temp */
+    private func setNavigationBar(title: String = "", step: String = "") {
+        let backButton: UIBarButtonItem = UIBarButtonItem(image: UIImage(.chevron_left), style: .plain, target: self, action: #selector(backButtonDidTap))
+        backButton.tintColor = .black
+        let progressLabel = UILabel()
+        progressLabel.text = step
+        progressLabel.font = UIFont.www.body3
+        let progressItem: UIBarButtonItem = UIBarButtonItem(customView: progressLabel)
+        navigationItem.leftBarButtonItem = backButton
+        navigationItem.rightBarButtonItem = progressItem
+        navigationItem.title = title
+    }
+    
+    @objc func backButtonDidTap() {}
+    
+}
+
+// MARK: - Binding
+private extension UserNameViewController {
+    func bindViewModel() {
+        let input = UserNameViewModel.Input(
+            viewDidLoad:
+                Observable.just(()).asObservable(),
+            codeTextFieldDidEdit:
+                textFieldView.textField.rx.text.orEmpty.asObservable(),
+            nextButtonDidTap:
+                self.nextButton.rx.tap.asObservable(),
+            backButtonDidTap:
+                self.navigationItem.leftBarButtonItem!.rx.tap.asObservable()
+        )
+        
+        let output = self.viewModel?.transform(input: input, disposeBag: self.disposeBag)
+        
+        self.bindPager(output: output)
+        
+        output?.nextButtonMakeEnable
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] isEnabled in
+                if isEnabled == true {
+                    self?.nextButton.setButtonState(true)
+                } else {
+                    self?.nextButton.setButtonState(false)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+    }
+    
+    func bindPager(output: UserNameViewModel.Output?){
+        output?.navigatePage
+            .asDriver(onErrorJustReturn: .error)
+            .drive(onNext: { [weak self] page in
+                switch page {
+                case .back:
+                    self?.navigationController?.popViewController(animated: true)
+                case .nickName:
+                    // TODO: 다음페이지 연결
+                    print("다음페이지로 넘어갑니다")
+                case .error: break
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+
+// MARK: - Preview
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct UserNameViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
+        UserNameViewController(viewModel: viewModel, userMode: .host).toPreview()
+    }
+}
+#endif

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
@@ -135,6 +135,7 @@ private extension UserNameViewController {
             .drive(onNext: { [weak self] title in
                 switch self?.userMode {
                 case .host:
+                    print(title)
                     self?.progressView.setProgress(current: 2, total: 6)
                     self?.setNavigationBar(title: title, step: "2/6")
                 case .guest:

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewController.swift
@@ -136,7 +136,7 @@ private extension UserNameViewController {
                 switch self?.userMode {
                 case .host:
                     self?.progressView.setProgress(current: 2, total: 6)
-                    self?.setNavigationBar(title: "넥스터즈 뒷풀이", step: "2/6")
+                    self?.setNavigationBar(title: title, step: "2/6")
                 case .guest:
                     self?.progressView.setProgress(current: 2, total: 4)
                     self?.setNavigationBar(title: title, step: "2/4")
@@ -186,7 +186,7 @@ import SwiftUI
 
 struct UserNameViewController_Preview: PreviewProvider {
     static var previews: some View {
-        let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase())
+        let viewModel = UserNameViewModel(joinGuestUseCase: JoinGuestUseCase(), joinHostUseCase: nil)
         UserNameViewController(viewModel: viewModel, userMode: .host).toPreview()
     }
 }

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewModel.swift
@@ -23,15 +23,16 @@ final class UserNameViewModel: BaseViewModel {
     
     struct Input {
         let viewDidLoad: Observable<Void>
-        let codeTextFieldDidEdit: Observable<String>
+        let userNameDidEdit: Observable<String>
         let nextButtonDidTap: Observable<Void>
         let backButtonDidTap: Observable<Void>
     }
     
     struct Output {
+        var naviTitleText = BehaviorRelay<String>(value: "")
         var roomNameTextFieldText = BehaviorRelay<String>(value: "")
         var nextButtonMakeEnable = BehaviorRelay<Bool>(value: false)
-        var navigatePage = PublishRelay<RoomCodePager>()
+        var navigatePage = PublishRelay<UserNamePager>()
     }
     
     init(joinGuestUseCase: JoinGuestUseCase) {
@@ -45,18 +46,18 @@ final class UserNameViewModel: BaseViewModel {
     }
     
     private func handleInput(_ input: Input, disposeBag: DisposeBag) {
-        input.codeTextFieldDidEdit
-            .bind(to: self.usecase.roomCode)
+        input.userNameDidEdit
+            .bind(to: self.usecase.userName)
             .disposed(by: disposeBag)
     }
     
     private func makeOutput(with input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        self.usecase.roomCode
+        self.usecase.userName
             .compactMap { $0 }
-            .subscribe(onNext: { roomname in
-                if roomname != "" {
+            .subscribe(onNext: { userName in
+                if userName != "" {
                     output.nextButtonMakeEnable.accept(true)
                 } else {
                     output.nextButtonMakeEnable.accept(false)
@@ -70,9 +71,15 @@ final class UserNameViewModel: BaseViewModel {
             })
             .disposed(by: disposeBag)
         
+        input.viewDidLoad
+            .subscribe(onNext: {
+                output.naviTitleText.accept(self.usecase.roomName)
+            })
+            .disposed(by: disposeBag)
+        
         input.nextButtonDidTap
             .subscribe(onNext: {
-                output.navigatePage.accept(.nickName)
+                output.navigatePage.accept(.timeslot)
             })
             .disposed(by: disposeBag)
         

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  UserNameViewModel.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/09.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+
+enum UserNamePager {
+    case back
+    case calendar
+    case timeslot
+    case error
+}
+
+final class UserNameViewModel: BaseViewModel {
+    
+    // MARK: - Properties
+    private let usecase: JoinGuestUseCase
+    
+    struct Input {
+        let viewDidLoad: Observable<Void>
+        let codeTextFieldDidEdit: Observable<String>
+        let nextButtonDidTap: Observable<Void>
+        let backButtonDidTap: Observable<Void>
+    }
+    
+    struct Output {
+        var roomNameTextFieldText = BehaviorRelay<String>(value: "")
+        var nextButtonMakeEnable = BehaviorRelay<Bool>(value: false)
+        var navigatePage = PublishRelay<RoomCodePager>()
+    }
+    
+    init(joinGuestUseCase: JoinGuestUseCase) {
+        self.usecase = joinGuestUseCase
+    }
+
+    // MARK: - Transform
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+        self.handleInput(input, disposeBag: disposeBag)
+        return makeOutput(with:  input, disposeBag: disposeBag)
+    }
+    
+    private func handleInput(_ input: Input, disposeBag: DisposeBag) {
+        input.codeTextFieldDidEdit
+            .bind(to: self.usecase.roomCode)
+            .disposed(by: disposeBag)
+    }
+    
+    private func makeOutput(with input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        
+        self.usecase.roomCode
+            .compactMap { $0 }
+            .subscribe(onNext: { roomname in
+                if roomname != "" {
+                    output.nextButtonMakeEnable.accept(true)
+                } else {
+                    output.nextButtonMakeEnable.accept(false)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        input.backButtonDidTap
+            .subscribe(onNext: {
+                output.navigatePage.accept(.back)
+            })
+            .disposed(by: disposeBag)
+        
+        input.nextButtonDidTap
+            .subscribe(onNext: {
+                output.navigatePage.accept(.nickName)
+            })
+            .disposed(by: disposeBag)
+        
+        return output
+    }
+}
+

--- a/Projects/App/Sources/Presentation/Join/UserName/UserNameViewModel.swift
+++ b/Projects/App/Sources/Presentation/Join/UserName/UserNameViewModel.swift
@@ -112,17 +112,15 @@ extension UserNameViewModel {
         self.usecaseHost!.userName
             .compactMap { $0 }
             .subscribe(onNext: { userName in
-                if userName != "" {
-                    output.nextButtonMakeEnable.accept(true)
-                } else {
-                    output.nextButtonMakeEnable.accept(false)
-                }
+                output.nextButtonMakeEnable.accept(userName != "" ? true : false)
             })
             .disposed(by: disposeBag)
         
-        self.usecaseHost!.roomName
-            .map { $0 }
-            .bind(to: output.naviTitleText)
+        input.viewDidLoad
+            .subscribe(onNext: {
+                guard let roomName = try? self.usecaseHost!.roomName.value() else { return }
+                output.naviTitleText.accept(roomName)
+            })
             .disposed(by: disposeBag)
         
         input.backButtonDidTap

--- a/Projects/App/Sources/Utils/Constants/UserType.swift
+++ b/Projects/App/Sources/Utils/Constants/UserType.swift
@@ -1,0 +1,14 @@
+//
+//  UserMode.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/09.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import Foundation
+
+enum UserType {
+    case host   // 방장
+    case guest  // 참가자
+}


### PR DESCRIPTION
## Background
<!-- 관련있는 이슈 번호(#000) 또는 작업 배경을 작성해주세요 -->
<!-- 이슈에 작업배경이 명시되어 있는 경우 대체 가능 -->
- closes #21 

## Description
1. 참가코드 입력화면
2. 닉네임 입력 화면
3. 화면 플로우 연결 (방장모드, 참가자 모드별)

=> 변수명은 백엔드와 통일을 위해 아래와 같이 지어 보았습니다
방장 : Host
참가자 : (반댓말인) Guest 

https://user-images.githubusercontent.com/63157395/217837241-4aedf48a-aac2-4dd6-8c87-0257d8bc43e4.mp4



## Extra Notes 

> SampleVC 에서 주석해제해서  참가자 방장 플로우 쉽게 테스트 하세요! 

1. 화면연결시 키보드 
snapkit keyboard 로 레이아웃을 맞춰서 그런가 입력 => 입력으로 가니깐 쨍그랑쨍그랑 거리는데 
다른 방법을 한번 고민해보겠습니다 

2. 화면 재사용
화면이 똑같은게 재사용이 되니깐 최대한 재사용을 하고 싶어서 
현재는 VC, VM 은 재사용하는 대신 viewmodel 에서 usecase 를 다른 것을 가져가면 되도록 만들었는데,, 

뭔가 너무 맘에 안드네요! 혹시 더 좋은 아이디어가 있다면 추천좀 부탁드립니다
<img width="200" src="https://user-images.githubusercontent.com/63157395/217838164-1d1489b0-b1bd-4322-88db-d12504f3eef6.png">



## 참고 사항
<!-- 참고할 사항(스크린샷, 실행 시 유의할 점, 참고 링크)이 있다면 적어주세요. -->
