### PR TITLE
[Feat] 디바이스 사이즈 대응 (feat. DeviceManager)

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -20,5 +20,6 @@ let project = Project.app(name: projectName,
                             .external(name: "RxSwift"),
                             .external(name: "RxCocoa"),
                             .external(name: "RxMoya"),
-                            .external(name: "SnapKit")
+                            .external(name: "SnapKit"),
+                            .external(name: "DeviceKit")
                           ])

--- a/Projects/App/Sources/Utils/Extension/CGFloat+.swift
+++ b/Projects/App/Sources/Utils/Extension/CGFloat+.swift
@@ -1,0 +1,21 @@
+//
+//  CGFloat+.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/19.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import UIKit
+
+extension CGFloat {
+    var horizontallyAdjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return self * ratio
+    }
+    
+    var verticallyAdjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 812
+        return self * ratio
+    }
+}

--- a/Projects/App/Sources/Utils/Extension/Double+.swift
+++ b/Projects/App/Sources/Utils/Extension/Double+.swift
@@ -1,0 +1,22 @@
+//
+//  Double+.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/19.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import UIKit
+
+extension Double {
+    var horizontallyAdjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return CGFloat(self) * ratio
+    }
+    
+    var verticallyAdjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 812
+        return self * ratio
+    }
+}
+

--- a/Projects/App/Sources/Utils/Helper/DeviceManager.swift
+++ b/Projects/App/Sources/Utils/Helper/DeviceManager.swift
@@ -1,0 +1,27 @@
+//
+//  DeviceManager.swift
+//  App
+//
+//  Created by Chanhee Jeong on 2023/02/19.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import DeviceKit
+
+private enum DeviceGroup {
+    case homeButtonDevice
+    var rawValue: [Device] {
+        switch self {
+        case .homeButtonDevice:
+            return [.iPhone8, .iPhone8Plus, .iPhoneSE2, .iPhoneSE3, .simulator(.iPhoneSE3)]
+        }
+    }
+}
+
+class DeviceManager {
+    static let shared: DeviceManager = DeviceManager()
+    
+    func isHomeButtonDevice() -> Bool {
+        return Device.current.isOneOf(DeviceGroup.homeButtonDevice.rawValue)
+    }
+}

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -22,7 +22,9 @@ let dependencies = Dependencies(
         .remote(
             url: "https://github.com/Moya/Moya.git",
             requirement: .upToNextMajor(from: "15.0.0")
-        )
+        ),
+        .remote(url: "https://github.com/devicekit/DeviceKit.git",
+                requirement: .upToNextMajor(from: "4.0.0"))
     ],
     platforms: [.iOS]
 )


### PR DESCRIPTION
## Background
<!-- 관련있는 이슈 번호(#000) 또는 작업 배경을 작성해주세요 -->
<!-- 이슈에 작업배경이 명시되어 있는 경우 대체 가능 -->
- closes #37 

## Description
DeviceKit 을 사용하여 아이폰 버전 확인 등 앱품질관리 용이성 및 가독성이 증대되었습니다.

- DeviceKit SPM 추가
- DeviceManager 생성
- 유용한 사용을 위한 Extension 추가  (ScrollView용)

iphone 13 mini (우리 피그마 디자인 시안기준) 에 맞게 비율이 변하도록 대응하였습니다
앞으로 작업할때 기기별 조절이 필요한 경우 각기기 인치에서 N.adjusted 하면 쉽게 대응가능!

```swift
// 사용방법
button.contentEdgeInsets = UIEdgeInsets(inset: 5.adjusted)

// 사용방법
DeviceManager.shared.isHomeButtonDevice()
```


## Extra Notes 
타임 선택 투표를 하다보니 디바이스 사이즈 대응이 어려워진다는 단점이 있느데요.
매번 SE를 대응하기에는 더욱이나 어려움이 있죠,,,

그래서 제가 항상 고민하다가 만들어낸 기가막힌 방법이 있는데 바로 Devicekit 을 활용한 방법입니다.

이 manager 는 사용하고 싶으면 사용해도 되고 안써도되는데 이거쓰면 UI 고민 싹 사라짐...
그리고 flow 쪽은 ui 통일성이 중요해서 나중에 관련 view 다 나오고 이걸로 리팩토링할게요!


## 참고 사항

자세한 내용은 아래 노션과 PR 을 참고해주세요 
- https://avery-in-ada.notion.site/85cf8ff99a03471bb3dab0232333e518
- https://github.com/HRHN-HaruHana/HRHN-iOS/pull/18