### PR TITLE
:sparkles: UserAPI 네트워크 플러그인, 로거 설정

### DIFF
--- a/Projects/App/Sources/Common/RxMoya.swift
+++ b/Projects/App/Sources/Common/RxMoya.swift
@@ -27,3 +27,51 @@ public class RxMoyaProvider<Target>: MoyaProvider<Target> where Target: TargetTy
     }.observe(on: SerialDispatchQueueScheduler(qos: .background))
   }
 }
+
+class LoggerPlugin: PluginType {
+    func willSend(_ request: RequestType, target: TargetType) {
+        guard let request = request.request else { return }
+        
+        var log = "-----> \(request.httpMethod ?? "")\n"
+        log.append(String(describing: request.url?.absoluteString ?? "") + "\n")
+        log.append("API: \(target)\n")
+        if let body = request.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
+            log.append("\(bodyString)\n")
+        }
+        log.append("-----> END\n")
+        print(log)
+    }
+    
+    func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
+        switch result {
+        case let .success(response):
+            onSuccess(response, target: target)
+        case let .failure(error):
+            onFailure(error, target: target)
+        }
+    }
+    
+    private func onSuccess(_ response: Response, target: TargetType) {
+        var log = "🙆‍♂️ ----------\(response.statusCode)----------\n"
+        log.append("API: \(target)\n")
+        response.response?.allHeaderFields.forEach {
+          log.append("\($0): \($1)\n")
+        }
+        if let responseStr = String(bytes: response.data, encoding: String.Encoding.utf8) {
+          log.append("\(responseStr)\n")
+        }
+        log.append("🙆‍♂️----------End----------\n")
+        print(log)
+    }
+    
+    private func onFailure(_ error: MoyaError, target: TargetType) {
+        if let response = error.response {
+            onSuccess(response, target: target)
+        }
+        
+        var log = "🙅‍♂️ ----------\(error.errorCode) \(target)----------\n"
+        log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error)\n")")
+        log.append("🙅‍♂️----------End----------\n")
+        print(log)
+    }
+}

--- a/Projects/App/Sources/Data/Network/MeetingAPI+Request.swift
+++ b/Projects/App/Sources/Data/Network/MeetingAPI+Request.swift
@@ -1,0 +1,39 @@
+//
+//  MeetingAPI+Request.swift
+//  App
+//
+//  Created by kokojong on 2023/02/22.
+//  Copyright © 2023 com.promise8. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+extension MeetingAPI {
+    struct Plugins {
+        var plugins: [PluginType]
+        
+        init(plugins: [PluginType] = []) {
+            self.plugins = plugins
+        }
+        
+        func callAsFunction() -> [PluginType] { self.plugins }
+    }
+    
+    static var provider: RxMoyaProvider<MeetingAPI> {
+        let plugins = Plugins(plugins: [LoggerPlugin()])
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.urlCredentialStorage = nil
+        let session = Session(configuration: configuration)
+        
+        return RxMoyaProvider<MeetingAPI>(
+            endpointClosure: { target in
+                MoyaProvider.defaultEndpointMapping(for: target)
+            },
+            session: session,
+            plugins: plugins()
+        )
+    }
+}

--- a/Projects/App/Sources/Data/Network/MeetingAPI.swift
+++ b/Projects/App/Sources/Data/Network/MeetingAPI.swift
@@ -50,5 +50,5 @@ extension MeetingAPI: TargetType {
 }
 
 struct MeetingAPIManager {
-    static let provider = RxMoyaProvider<MeetingAPI>()
+    static let provider: RxMoyaProvider<MeetingAPI> = MeetingAPI.provider
 }

--- a/Projects/App/Sources/Data/Network/UserAPI+Request.swift
+++ b/Projects/App/Sources/Data/Network/UserAPI+Request.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Moya
-import RxSwift
 
 extension UserAPI {
     struct Plugins {

--- a/Projects/App/Sources/Data/Network/UserAPI+Request.swift
+++ b/Projects/App/Sources/Data/Network/UserAPI+Request.swift
@@ -10,32 +10,30 @@ import Moya
 import RxSwift
 
 extension UserAPI {
-    private enum MoyaWrapper {
-        struct Plugins {
-            var plugins: [PluginType]
-            
-            init(plugins: [PluginType] = []) {
-                self.plugins = plugins
-            }
-            
-            func callAsFunction() -> [PluginType] { self.plugins }
+    struct Plugins {
+        var plugins: [PluginType]
+        
+        init(plugins: [PluginType] = []) {
+            self.plugins = plugins
         }
         
-        static var provider: MoyaProvider<UserAPI> {
-            let plugins = Plugins(plugins: [])
-            
-            let configuration = URLSessionConfiguration.default
-            configuration.timeoutIntervalForRequest = 30
-            configuration.urlCredentialStorage = nil
-            let session = Session(configuration: configuration)
-            
-            return MoyaProvider<UserAPI>(
-                endpointClosure: { target in
-                    MoyaProvider.defaultEndpointMapping(for: target)
-                },
-                session: session,
-                plugins: plugins()
-            )
-        }
+        func callAsFunction() -> [PluginType] { self.plugins }
+    }
+    
+    static var provider: RxMoyaProvider<UserAPI> {
+        let plugins = Plugins(plugins: [LoggerPlugin()])
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.urlCredentialStorage = nil
+        let session = Session(configuration: configuration)
+        
+        return RxMoyaProvider<UserAPI>(
+            endpointClosure: { target in
+                MoyaProvider.defaultEndpointMapping(for: target)
+            },
+            session: session,
+            plugins: plugins()
+        )
     }
 }

--- a/Projects/App/Sources/Data/Network/UserAPI.swift
+++ b/Projects/App/Sources/Data/Network/UserAPI.swift
@@ -51,5 +51,5 @@ extension UserAPI: TargetType {
 }
 
 struct UserAPIManager {
-    static let provider = RxMoyaProvider<UserAPI>()
+    static let provider: RxMoyaProvider<UserAPI> = UserAPI.provider
 }

--- a/Projects/App/Sources/Data/Repositories/MainHomeDAO.swift
+++ b/Projects/App/Sources/Data/Repositories/MainHomeDAO.swift
@@ -20,7 +20,6 @@ final class MainHomeDAO: MeetingRepository {
         
         return network.request(.getMeetings)
             .map(MeetingMainGetResponseDTO.self)
-            .do { print("MeetingMainGetResponseDTO", $0) }
             .map{ $0.result }
             .map{ $0.toDomain() }
             .asSingle()

--- a/Projects/App/Sources/Data/Repositories/UserDAO.swift
+++ b/Projects/App/Sources/Data/Repositories/UserDAO.swift
@@ -31,7 +31,7 @@ final class UserDAO: UserRepository {
     
     // MARK: - Repositories
     func makeUserRepository() -> UserRepository {
-        return UserDAO(network: RxMoyaProvider<UserAPI>())
+        return UserDAO(network: UserAPIManager.provider)
     }
 
 }

--- a/Projects/App/Sources/Presentation/Home/SampleViewController.swift
+++ b/Projects/App/Sources/Presentation/Home/SampleViewController.swift
@@ -33,6 +33,7 @@ class SampleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
+//        bindRx()
     }
 
     private func setUI() {
@@ -62,11 +63,11 @@ class SampleViewController: UIViewController {
 //        let viewModel = RoomCodeViewModel(joinGuestUseCase: JoinGuestUseCase())
 //        self.navigationController?.pushViewController(RoomCodeController(viewModel: viewModel), animated: true)
         
-//        output?.loginResult.subscribe {
-//            print("loginResult is", $0)
-//            UserDefaultKeyCase().setUserToken($0.result)
-//
-//        }.disposed(by: bag)
+        output?.loginResult.subscribe {
+            print("loginResult is", $0)
+            UserDefaultKeyCase().setUserToken($0.result)
+
+        }.disposed(by: bag)
     }
 }
 


### PR DESCRIPTION
## Background
<!-- 관련있는 이슈 번호(#000) 또는 작업 배경을 작성해주세요 -->
<!-- 이슈에 작업배경이 명시되어 있는 경우 대체 가능 -->
- closes #43 

## Description
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
<!-- 작업 내용에 대하여 적어주세요. --> 
<!-- Optional : 어떻게 해결했는지 자세히 알려주세요
### Solution (If bug)
-->

Moya의 plugin을 활용해서 Request와 Response를 받아왔습니다!
아래에 첨부된 이미지처럼 나옵니다 참고하십셔!


## Extra Notes 
<!-- Optional -->
<!-- 이 기능 및 버그에 대해 개인적인 견해가 있다면 작성해주세요 -->
<!-- 리뷰할때 유의할점 등을 작성해주세요  -->

이전에 작업했던게 거의 반쪽짜리..였던걸 깨닫고.. 반성합니닷..(로거 없는 세팅이라니..)
UserAPI / MeetingAPI를 나누지 않고 처리하고 싶은데 일단은...! 나눠져있습니다
추가로 response는 있으나 StatusCode가 200 이닌 부분에 대한 처리도 해야하눈뎁... (모른척)

## 참고 사항
<!-- 참고할 사항(스크린샷, 실행 시 유의할 점, 참고 링크)이 있다면 적어주세요. -->

<img width="947" alt="image" src="https://user-images.githubusercontent.com/61327153/220427107-cee6f35b-946b-4318-bfd6-13aa3eb89845.png">

<img width="1578" alt="image" src="https://user-images.githubusercontent.com/61327153/220427520-1b809432-c9f8-4eeb-bf67-f3222e8431c6.png">

참고링크: 
https://github.com/Moya/Moya/blob/master/docs/Plugins.md
https://gyuios.tistory.com/165

